### PR TITLE
Initial DomD run-time support

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -3,6 +3,8 @@ DEPENDS += "u-boot-mkimage-native"
 #Add Xen and additional packages to build
 IMAGE_INSTALL_append = " \
     xen-xencommons \
+    guest-addons \
+    domd-install-artifacts \
 "
 
 generate_uboot_image() {

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/domd-install-artifacts/domd-install-artifacts.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/domd-install-artifacts/domd-install-artifacts.bb
@@ -1,0 +1,23 @@
+LICENSE = "CLOSED"
+
+IMAGES_SRC_DIR="boot/domd"
+# TODO: use Xen defined location for storing domain artifacts
+IMAGES_DST_DIR="xt/domd"
+
+FILES_${PN} += "${base_prefix}/${IMAGES_DST_DIR}"
+
+# FIXME: if not forced and sstate cache is used then an old version of
+# this package (read old DomU kernel images) can be used from cache
+# regardless of the fact that binaries may have actually changed, e.g.
+# the recipe code is not changed, there is no SRC_URI with checksum
+# force install so if DomU kernel changes we use the latest binaries
+do_install[nostamp] = "1"
+do_install() {
+   install -d "${D}/${base_prefix}/${IMAGES_DST_DIR}"
+   find "${XT_SHARED_ROOTFS_DIR}/${IMAGES_SRC_DIR}" -iname 'Image*' -exec \
+     cp -f --no-dereference --preserve=links {} "${D}/${base_prefix}/${IMAGES_DST_DIR}" \;
+
+   find "${XT_SHARED_ROOTFS_DIR}/${IMAGES_SRC_DIR}" -iname 'dom*.dtb' -exec \
+     cp -f --no-dereference --preserve=links {} "${D}/${base_prefix}/${IMAGES_DST_DIR}" \;
+}
+

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd.cfg
@@ -1,0 +1,25 @@
+# =====================================================================
+# DomD guest configuration
+# =====================================================================
+
+seclabel='system_u:system_r:domU_t'
+
+# Guest name
+name = "DomD"
+
+# Kernel image to boot
+kernel = "/xt/domd/Image"
+
+device_tree = "/xt/domd/domd.dtb"
+
+# Kernel command line options
+extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd ip=192.168.1.11 rw rootwait console=hvc0 cma=64M"
+
+# Initial memory allocation (MB)
+memory = 512
+
+# Number of VCPUS
+vcpus = 4
+
+on_crash = 'preserve'
+

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
@@ -1,0 +1,30 @@
+# Copyright
+# License:
+#
+# Filename: guest-addons.bb
+
+SUMMARY = "config files and scripts for a guest"
+DESCRIPTION = "config files and scripts for guest which will be running for tests"
+PV = "0.1"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+SRC_URI = "\
+    file://domd.cfg \
+"
+
+S = "${WORKDIR}"
+
+# TODO: use Xen defined location for storing domain artifacts
+IMAGE_DST_DIR = "xt"
+IMAGE_DST_DIR_DOMD = "${IMAGE_DST_DIR}/domd"
+
+do_install() {
+    install -d ${D}${base_prefix}/${IMAGE_DST_DIR_DOMD}
+    install -m 0744 ${WORKDIR}/domd.cfg ${D}${base_prefix}/${IMAGE_DST_DIR_DOMD}
+}
+
+FILES_${PN} += " \
+    ${base_prefix}/${IMAGE_DST_DIR_DOMD}/*.cfg \
+"
+

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-domd.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-domd.dts
@@ -36,39 +36,10 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	model = "Renesas Salvator-X board based on r8a7795";
-	compatible = "renesas,salvator-x", "renesas,r8a7795";
-
 	aliases {
 		serial0 = &scif2;
 		serial1 = &scif1;
 		ethernet0 = &avb;
-	};
-
-	chosen {
-		bootargs = "dom0_mem=752M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 flask_enforcing=1 loglvl=all dom0_coprocs=/soc/gsx@fd000000";
-		xen,dom0-bootargs = "console=hvc0 root=/dev/nfs nfsroot=192.168.1.100:/srv/dom0 ip=192.168.1.10 rw rootwait rootfstype=ext4 ignore_loglevel cma=128M";
-		modules {
-			#address-cells = <2>;
-			#size-cells = <2>;
-			module@1 {
-				compatible = "xen,linux-zimage", "xen,multiboot-module";
-				reg = <0x0 0x7a000000 0x0 0x02000000>;
-			};
-			module@2 {
-				compatible = "xen,xsm-policy", "xen,multiboot-module";
-				reg = <0x0 0x7c000000 0x0 0x10000>;
-			};
-		};
-	};
-
-	memory@48000000 {
-		device_type = "memory";
-		/* first 128MB is reserved for secure area. */
-		reg = <0x0 0x48000000 0x0 0x38000000>,
-			  <0x5 0x00000000 0x0 0x40000000>,
-			  <0x6 0x00000000 0x0 0x40000000>,
-			  <0x7 0x00000000 0x0 0x40000000>;
 	};
 
 	avb-mch {

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-domd.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-domd.dts
@@ -36,37 +36,13 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	model = "Renesas Salvator-X board based on r8a7796";
-	compatible = "renesas,salvator-x", "renesas,r8a7796";
+	passthrough {
+	};
 
 	aliases {
 		serial0 = &scif2;
 		serial1 = &scif1;
 		ethernet0 = &avb;
-	};
-
-	chosen {
-		bootargs = "dom0_mem=752M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 flask_enforcing=1 loglvl=all dom0_coprocs=/soc/gsx@fd000000";
-		xen,dom0-bootargs = "console=hvc0 root=/dev/nfs nfsroot=192.168.1.100:/srv/dom0 ip=192.168.1.10 rw rootwait rootfstype=ext4 ignore_loglevel cma=128M";
-		modules {
-			#address-cells = <2>;
-			#size-cells = <2>;
-			module@1 {
-				compatible = "xen,linux-zimage", "xen,multiboot-module";
-				reg = <0x0 0x7a000000 0x0 0x02000000>;
-			};
-			module@2 {
-				compatible = "xen,xsm-policy", "xen,multiboot-module";
-				reg = <0x0 0x7c000000 0x0 0x10000>;
-			};
-		};
-	};
-
-	memory@48000000 {
-		device_type = "memory";
-		/* first 128MB is reserved for secure area. */
-		reg = <0x0 0x48000000 0x0 0x78000000>,
-		      <0x6 0x00000000 0x0 0x80000000>;
 	};
 
 	avb-mch {


### PR DESCRIPTION
Add all required configuration and other files needed to
run DomD as Xen domain:
  - copy DomD Linux kernel image and device trees into Dom0 image
  - add DomD xl configuration file
  - remove parts of the DomD device tree like memory, chosen
    which are provided by Xen for guest domains

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>