### PR TITLE
Workaround QA issue while packaging Xen policy file

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -14,7 +14,7 @@ PACKAGECONFIG[xsm] = ""
 do_install_append() {
     # FIXME: we do not want XSM, but Xen still installs it making
     # package QA Issue to raise for files installed
-    rm ${D}/boot/xenpolicy-${XEN_REL}-rc
+    rm ${D}/boot/xenpolicy-${XEN_REL}-rc || true
 
     # FIXME: this is to fix run-time issues
     # "libxl__lock_domain_userdata: Domain 0:cannot open lockfile /var/lib/xen/"


### PR DESCRIPTION
For some reason some of the build machines produce and install
xenpolicy file into the final image making QA complain.
Try removing the file and do not fail the build if it doesn't
exist.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>