### PR TITLE
Enable IOMMUs for VSP

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd.cfg
@@ -82,6 +82,9 @@ dtdev = [
     "/soc/usb@ee0a0100",
     "/soc/usb@ee080000",
     "/soc/usb@ee0a0000",
+    "/soc/fcp@fea27000",
+    "/soc/fcp@fea2f000",
+    "/soc/fcp@fea37000",
 ]
 
 irqs = [

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-dom0.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-dom0.dts
@@ -1010,8 +1010,24 @@
 	status = "okay";
 };
 
+&ipmmu_vi {
+	status = "okay";
+};
+
 &gsx {
 	xen,coproc;
+};
+
+&fcpvd0 {
+	iommus = <&ipmmu_vi 8>;
+};
+
+&fcpvd1 {
+	iommus = <&ipmmu_vi 9>;
+};
+
+&fcpvd2 {
+	iommus = <&ipmmu_vi 10>;
 };
 
 /* ============================ Xen pass through section ============================ */
@@ -1117,4 +1133,8 @@
 &tsc1		{ xen,passthrough; };
 &tsc2		{ xen,passthrough; };
 &tsc3		{ xen,passthrough; };
+
+&fcpvd0		{ xen,passthrough; };
+&fcpvd1		{ xen,passthrough; };
+&fcpvd2		{ xen,passthrough; };
 

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-domd.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-domd.dts
@@ -976,6 +976,18 @@
 	clock-frequency = <133333333>;
 };
 
+&fcpvd0 {
+	/delete-property/iommus;
+};
+
+&fcpvd1 {
+	/delete-property/iommus;
+};
+
+&fcpvd2 {
+	/delete-property/iommus;
+};
+
 /* Xen will provide its own GIC, mask ours */
 &gic {
 	compatible = "";


### PR DESCRIPTION
Enable ipmmu_vi/fcpvd[0:2] for VSP module.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>