### PR TITLE
Fix coproc settings

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd.cfg
@@ -21,7 +21,7 @@ memory = 512
 # Number of VCPUS
 vcpus = 4
 
-coprocs = [ "/soc/gsx@fd000000" ]
+coproc = [ "/soc/gsx@fd000000" ]
 
 on_crash = 'preserve'
 
@@ -374,7 +374,7 @@ iomem = [
 #sound@ec500000
     "ec008,1",
 #gsx@fd000000 handled by coproc framework
-#    "fd000,40",
+    "fd001,3f",
 #vsp@fe960000
 #vspm@fe960000
     "fe960,8",


### PR DESCRIPTION
1. coprocs -> coproc paramter name in config file
2. GSX coproc maps a single page of the IOMEM range,
the rest needs to be mapped by the domain.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>