### PR TITLE
Bump CMA to 128MB for DomD

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd.cfg
@@ -13,7 +13,7 @@ kernel = "/xt/domd/Image"
 device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
-extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd ip=192.168.1.11 rw rootwait console=hvc0 cma=64M"
+extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd ip=192.168.1.11 rw rootwait console=hvc0 cma=128M"
 
 # Initial memory allocation (MB)
 memory = 512


### PR DESCRIPTION
Although it is enough ~80MB to start dual headed Weston
bump CMA memory to 128MB:
 - 32 MB is used by PVR KM FW heap
 - 8MB per buffer @1080p

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>