### PR TITLE
Use master branch for Xen-troops backends

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/displbe/displbe_git.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/displbe/displbe_git.bbappend
@@ -3,6 +3,6 @@
 ################################################################################
 SRCREV_rcar = "${AUTOREV}"
 
-SRC_URI_append_rcar = " git://github.com/xen-troops/displ_be.git;protocol=https;branch=vgpu-dev"
+SRC_URI_append_rcar = " git://github.com/xen-troops/displ_be.git;protocol=https;branch=master"
 
 EXTRA_OECMAKE_append_rcar = " -DWITH_DOC=OFF -DWITH_DRM=ON -DWITH_ZCOPY=OFF -DWITH_WAYLAND=ON -DWITH_IVI_EXTENSION=OFF -DWITH_INPUT=ON"

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/libxenbe/libxenbe_git.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/libxenbe/libxenbe_git.bbappend
@@ -3,4 +3,4 @@
 ################################################################################
 SRCREV_rcar = "${AUTOREV}"
 
-SRC_URI_append_rcar = " git://github.com/xen-troops/libxenbe.git;protocol=https;branch=vgpu-dev"
+SRC_URI_append_rcar = " git://github.com/xen-troops/libxenbe.git;protocol=https;branch=master"

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/sndbe/sndbe_git.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/sndbe/sndbe_git.bbappend
@@ -3,6 +3,6 @@
 ################################################################################
 SRCREV_rcar = "${AUTOREV}"
 
-SRC_URI_append_rcar = " git://github.com/xen-troops/snd_be.git;protocol=https;branch=vgpu-dev"
+SRC_URI_append_rcar = " git://github.com/xen-troops/snd_be.git;protocol=https;branch=master"
 
 EXTRA_OECMAKE_append_rcar = " -DWITH_DOC=OFF -DWITH_PULSE=ON"


### PR DESCRIPTION
Use master branch for sound and display backends
together with libxenbe.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>