### PR TITLE
Eliminate a misprint in u-boot documentation

### DIFF
--- a/doc/u-boot-env-salvator-x-h3-m3.txt
+++ b/doc/u-boot-env-salvator-x-h3-m3.txt
@@ -12,7 +12,7 @@ setenv filesize da4e00
 
 setenv dtb_load_tftp tftp 0x48000000 dom0.dtb
 setenv xen_load_tftp tftp 0x48080000 xen-uImage
-setenv initramfs_load_tftp=tftp 0x76000000 uInitramfs
+setenv initramfs_load_tftp tftp 0x76000000 uInitramfs
 setenv kernel_load_tftp tftp 0x7a000000 Image
 setenv xenpolicy_load_tftp tftp 0x7c000000 xenpolicy
 


### PR DESCRIPTION
Eliminate a misprint in u-boot documentation which turns copy-paste in error.
