### PR TITLE
Provide MACHINEOVERRIDES from DomD to Dom0

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/local.conf.dom0-image-minimal-initramfs
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/local.conf.dom0-image-minimal-initramfs
@@ -221,3 +221,6 @@ CONF_VERSION = "1"
 DEPLOY_DIR = "${TMPDIR}/deploy"
 IMAGE_ROOTFS = "${TMPDIR}/rootfs"
 XT_SHARED_ROOTFS_DIR = "${IMAGE_ROOTFS}/shared_rootfs"
+
+include ${@d.getVar('XT_SHARED_ROOTFS_DIR', True) or ''}/local.conf.domd_machine.inc
+

--- a/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
@@ -23,6 +23,12 @@ EXTRA_IMAGEDEPENDS += " arm-trusted-firmware"
 # u-boot
 EXTRA_IMAGEDEPENDS += " u-boot"
 
+# Dom0 is a generic ARMv8 machine w/o machine overrides,
+# but still needs to know which system we are building,
+# e.g. Salvator-X M3 or H3, for instance
+# So, we provide machine overrides from this build to Dom0
+EXTRA_IMAGEDEPENDS += " domd-install-machine-overrides"
+
 # Do not support secure environment
 IMAGE_INSTALL_remove = " \
     optee-linuxdriver \

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/domd-install-machine-overrides/domd-install-machine-overrides.bb
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/domd-install-machine-overrides/domd-install-machine-overrides.bb
@@ -1,0 +1,13 @@
+LICENSE = "CLOSED"
+
+# FIXME: if not forced and sstate cache is used then an old version of
+# this package (read old DomU kernel images) can be used from cache
+# regardless of the fact that binaries may have actually changed, e.g.
+# the recipe code is not changed, there is no SRC_URI with checksum
+# force install so if DomU kernel changes we use the latest binaries
+do_install[nostamp] = "1"
+do_install() {
+     install -d ${XT_SHARED_ROOTFS_DIR}
+     echo "MACHINEOVERRIDES .= \":${MACHINEOVERRIDES}\"" > "${XT_SHARED_ROOTFS_DIR}/local.conf.domd_machine.inc"
+}
+


### PR DESCRIPTION
Dom0 is a generic ARMv8 machine w/o machine overrides,
but still needs to know which system we are building,
e.g. Salvator-X M3 or H3, for instance
So, we provide machine overrides from this build to Dom0
for it to use MACHINEOVERRIDES while dealing with
configuration files etc.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>