### PR TITLE
doma: Unpack lz4 packed kernel

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-prod-extra/recipes-extended/android/android.bbappend
+++ b/recipes-domu/domu-image-android/files/meta-xt-prod-extra/recipes-extended/android/android.bbappend
@@ -14,6 +14,7 @@ EXTRA_OEMAKE_append = " \
 # where "repo" is hardcoded in bitbake's repo fetcher
 ANDROID_ARTIFACTS_DIR = "${ANDROID_OUT_DIR_COMMON_BASE}/repo/target/product/${ANDROID_PRODUCT}/"
 ANDROID_KERNEL_NAME ?= "kernel"
+ANDROID_UNPACKED_KERNEL_NAME ?= "vmlinux"
 
 ################################################################################
 # Renesas R-Car
@@ -37,16 +38,19 @@ do_install[nostamp] = "1"
 do_install() {
     install -d "${DEPLOY_DIR_IMAGE}"
 
-    # copy kernel to shared folder, so Dom0 can pick it up
+    # uncompress lz4 packed kernel
+    lz4 -d "${ANDROID_ARTIFACTS_DIR}/${ANDROID_KERNEL_NAME}" "${ANDROID_ARTIFACTS_DIR}/${ANDROID_UNPACKED_KERNEL_NAME}"
+    # copy uncompressed kernel to shared folder, so Dom0 can pick it up
     install -d "${XT_DIR_ABS_SHARED_BOOT_DOMA}"
-    install -m 0744 "${ANDROID_ARTIFACTS_DIR}/${ANDROID_KERNEL_NAME}" "${XT_DIR_ABS_SHARED_BOOT_DOMA}"
-    ln -sfr "${XT_DIR_ABS_SHARED_BOOT_DOMA}/${ANDROID_KERNEL_NAME}" "${XT_DIR_ABS_SHARED_BOOT_DOMA}/Image"
+    install -m 0744 "${ANDROID_ARTIFACTS_DIR}/${ANDROID_UNPACKED_KERNEL_NAME}" "${XT_DIR_ABS_SHARED_BOOT_DOMA}"
+    ln -sfr "${XT_DIR_ABS_SHARED_BOOT_DOMA}/${ANDROID_UNPACKED_KERNEL_NAME}" "${XT_DIR_ABS_SHARED_BOOT_DOMA}/Image"
 
     # copy images to the deploy directory
     find "${ANDROID_ARTIFACTS_DIR}/" -maxdepth 1 -iname '*.img' -exec \
         cp -f --no-dereference --preserve=links {} "${DEPLOY_DIR_IMAGE}" \;
     # and the kernel as well
     install -m 0744 "${ANDROID_ARTIFACTS_DIR}/${ANDROID_KERNEL_NAME}" "${DEPLOY_DIR_IMAGE}"
-    ln -sfr "${XT_DIR_ABS_SHARED_BOOT_DOMA}/${ANDROID_KERNEL_NAME}" "${DEPLOY_DIR_IMAGE}/Image"
+    install -m 0744 "${ANDROID_ARTIFACTS_DIR}/${ANDROID_UNPACKED_KERNEL_NAME}" "${DEPLOY_DIR_IMAGE}"
+    ln -sfr "${DEPLOY_DIR_IMAGE}/${ANDROID_UNPACKED_KERNEL_NAME}" "${DEPLOY_DIR_IMAGE}/Image"
 }
 


### PR DESCRIPTION
Xen cannot decompress lz4 packed kernel on domain creation,
so unpack it while installing.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>