### PR TITLE
doma: Provide gcc/g++ 5 as provided host tools

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-prod-extra/doc/local.conf.domu-image-android
+++ b/recipes-domu/domu-image-android/files/meta-xt-prod-extra/doc/local.conf.domu-image-android
@@ -221,6 +221,12 @@ PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"
 ASSUME_PROVIDED += "repo-native"
 HOSTTOOLS += "repo"
 
+# PVR DDK dependencies
+ASSUME_PROVIDED += "gcc-5-native"
+ASSUME_PROVIDED += "g\+\+-5-native"
+HOSTTOOLS += "gcc-5"
+HOSTTOOLS += "g++-5"
+
 DEPLOY_DIR = "${TMPDIR}/deploy"
 IMAGE_ROOTFS = "${TMPDIR}/rootfs"
 XT_SHARED_ROOTFS_DIR = "${IMAGE_ROOTFS}/shared_rootfs"


### PR DESCRIPTION
PVR DDK depends on gcc/g++ v5, so provide these.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>