### PR TITLE
doma: Pass Android vendor mount opts via dtb

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-doma.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-doma.dts
@@ -16,6 +16,24 @@
 		};
 	};
 
+	firmware {
+		android {
+			compatible = "android,firmware";
+
+			fstab {
+				compatible = "android,fstab";
+
+				vendor {
+					compatible = "android,vendor";
+					dev = "/dev/block/xvdb";
+					type = "ext4";
+					mnt_flags = "ro,barrier=1";
+					fsmgr_flags = "wait,slotselect,avb";
+				};
+			};
+		};
+	};
+
 	/* keep this to make XEN happy */
 	passthrough {
 	};

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-doma.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-doma.dts
@@ -16,6 +16,24 @@
 		};
 	};
 
+	firmware {
+		android {
+			compatible = "android,firmware";
+
+			fstab {
+				compatible = "android,fstab";
+
+				vendor {
+					compatible = "android,vendor";
+					dev = "/dev/block/xvdb";
+					type = "ext4";
+					mnt_flags = "ro,barrier=1";
+					fsmgr_flags = "wait,slotselect,avb";
+				};
+			};
+		};
+	};
+
 	/* keep this to make XEN happy */
 	passthrough {
 	};


### PR DESCRIPTION
Android expects that vendor mount point is passed via
device tree.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>
Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>