### PR TITLE
doma/cfg: Pass DriverMode for PVR KM

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma.cfg
@@ -41,7 +41,7 @@ disk = [
 #]
 
 # Kernel command line options
-extra = "root=/dev/xvda1 androidboot.hardware=salvator skip_initramfs init=/init ro rootwait console=hvc0 cma=384M printk.devkmsg=on androidboot.slot_suffix=1 androidboot.selinux=permissive"
+extra = "root=/dev/xvda1 androidboot.hardware=salvator skip_initramfs init=/init ro rootwait console=hvc0 cma=384M printk.devkmsg=on androidboot.slot_suffix=1 androidboot.selinux=permissive pvrsrvkm.DriverMode=1"
 
 # Initial memory allocation (MB)
 memory = 2048


### PR DESCRIPTION
Set Guest mode for PVR KM running in DomA.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>