### PR TITLE
domd: Add scripts for loop setup and control

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma_loop_detach.sh
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma_loop_detach.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -x
+
+# Android partitions
+# system   - xvda1
+# vendor   - xvdb1
+# misc     - xvdc1
+# userdata - xvdd1
+
+losetup -d /dev/loop0
+losetup -d /dev/loop1
+losetup -d /dev/loop2
+losetup -d /dev/loop3
+

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma_loop_setup.sh
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma_loop_setup.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -x
+
+# Android partitions
+# system   - xvda1
+# vendor   - xvdb1
+# misc     - xvdc1
+# userdata - xvdd1
+
+losetup /dev/loop0 system.raw
+losetup /dev/loop1 vendor.raw
+losetup /dev/loop2 misc.raw
+losetup /dev/loop3 userdata.raw
+

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
@@ -10,6 +10,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 SRC_URI = " \
     file://bridge-nfsroot.sh \
     file://bridge.sh \
+    file://doma_loop_detach.sh \
+    file://doma_loop_setup.sh \
 "
 
 S = "${WORKDIR}"


### PR DESCRIPTION
These are helper scripts to setup required loop devices
for Android images, so these can be used in doma.cfg.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>