### PR TITLE
domd: Use Linux libc headers from xen-troops kernel

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,0 +1,4 @@
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+
+BRANCH = "ces2018"
+SRCREV = "${AUTOREV}"


### PR DESCRIPTION
The kernel in use for DomD/AGL is xen-troops one,
so switch Linux libc headers to point to the same.

This is in particular needed for DRM zero-copy UAPI
be available to user-space (display backend).

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>