### PR TITLE
Revert "domd: Workaround long login time"

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/pam/libpam_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/pam/libpam_%.bbappend
@@ -1,8 +1,0 @@
-# workaround dbus/systemd long login:
-# https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1591411/comments/4
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=770135#133
-
-do_install_append () {
-    sed -i '/pam_systemd.so/ s/^/#/' ${D}${sysconfdir}/pam.d/common-session
-}
-


### PR DESCRIPTION
This reverts commit fcb412a3c813b67ff185ac6e407cc9d94d288327.

Suggested fix has a nasty side effect: `systemd --user` is not started
what consequently prevents any user services from starting.
So we revert it.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>