### PR TITLE
Fix unstripped Linux Kernel installation

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -7,6 +7,6 @@ SRC_URI = " \
     git://github.com/xen-troops/linux.git;branch=${BRANCH} \
     file://defconfig \
   "
-do_deploy_append () {
+do_install_append () {
     find ${D}/boot -iname "vmlinux*" -exec tar -cJvf ${DEPLOY_DIR_IMAGE}/vmlinux.tar.xz {} \;
 }

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -70,7 +70,9 @@ do_deploy_append() {
                   break
               done
         done
+}
 
+do_install_append() {
     find ${D}/boot -iname "vmlinux*" -exec tar -cJvf ${DEPLOY_DIR_IMAGE}/vmlinux.tar.xz {} \;
 }
 

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -12,7 +12,7 @@ SRC_URI = " \
 
 DEPLOYDIR="${XT_DIR_ABS_SHARED_BOOT_DOMF}"
 
-do_deploy_append () {
+do_install_append () {
     find ${D}/boot -iname "vmlinux*" -exec tar -cJvf ${DEPLOY_DIR_IMAGE}/vmlinux.tar.xz {} \;
 }
 


### PR DESCRIPTION
At the time of do_deploy uncompressed vmlinux is not yet
installed into boot deirectory, but at do_install time.
Fix this to run after installation of the kernel.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>