### PR TITLE
Revert SMACK disabling

### DIFF
--- a/recipes-domd/agl/files/meta-agl-bsp/conf/include/agl_rcar_xt.inc
+++ b/recipes-domd/agl/files/meta-agl-bsp/conf/include/agl_rcar_xt.inc
@@ -47,8 +47,6 @@ IMAGE_INSTALL_append_rcar-gen3 = " \
 BBMASK .= "|meta-renesas-rcar-gen3/meta-rcar-gen3/recipes-forward-port/"
 # FIXME: this recipe makes problems during recipe parsing
 BBMASK .= "|meta-virtualization/recipes-containers/docker"
-# XXX: disable smack security so we can boot with nfsroot
-BBMASK .= "|meta-intel-iot-security/meta-security-smack/recipes-kernel/linux"
 
 # remove OMX and dependecies
 BBMASK .= "|kernel-module-uvcs-drv|omx-user-module|gstreamer1.0-omx"

--- a/recipes-domu/domu-image-fusion/domu-image-fusion.bbappend
+++ b/recipes-domu/domu-image-fusion/domu-image-fusion.bbappend
@@ -9,7 +9,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 XT_QUIRK_UNPACK_SRC_URI += "\
     file://xt_shared_env.inc;subdir=repo/meta-xt-prod-extra/inc \
     file://meta-xt-prod-extra;subdir=repo \
-    file://50_local.conf.inc;subdir=repo/meta-agl/templates/machine/generic-armv8-xt \
 "
 
 XT_QUIRK_BB_ADD_LAYER += " \

--- a/recipes-domu/domu-image-fusion/files/50_local.conf.inc
+++ b/recipes-domu/domu-image-fusion/files/50_local.conf.inc
@@ -1,4 +1,0 @@
-# XXX: disable smack security so we can boot with nfsroot
-# FIXME: at the moment this is the first occurance of BBMASK
-# for the build, so we cannot use .= syntax here as configuration fails
-BBMASK = "meta-intel-iot-security/meta-security-smack/recipes-kernel/linux"


### PR DESCRIPTION
SMACK is required to launch AGL demo. But it will break NFS boot. Only SD card boot will be available.