### PR TITLE
domf/defconfig: Enable packet socket

### DIFF
--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8/defconfig
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8/defconfig
@@ -484,7 +484,8 @@ CONFIG_NET=y
 #
 # Networking options
 #
-# CONFIG_PACKET is not set
+CONFIG_PACKET=y
+# CONFIG_PACKET_DIAG is not set
 CONFIG_UNIX=y
 # CONFIG_UNIX_DIAG is not set
 CONFIG_XFRM=y


### PR DESCRIPTION
This is required for DHCP to work.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>