### PR TITLE
New network configuration

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
@@ -15,6 +15,7 @@ IMAGE_INSTALL_append = " \
 
 #Add Xen and additional packages to build
 IMAGE_INSTALL_append = " \
+    dnsmasq \
     nftables \
     dhcp-client \
     xen-base \

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/connman/connman_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/connman/connman_%.bbappend
@@ -1,13 +1,20 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://main.conf"
+SRC_URI += " \
+    file://main.conf \
+    file://disable_dns_proxy.conf \
+"
 
 FILES_${PN} += " \
     ${sysconfdir}/main.conf \
+    ${sysconfdir}/systemd/system/connman.service.d/disable_dns_proxy.conf \
 "
 
 do_install_append() {
     install -d ${D}${sysconfdir}/connman
     install -m 0644 ${WORKDIR}/main.conf ${D}${sysconfdir}/connman/main.conf
+
+    install -d ${D}${sysconfdir}/systemd/system/connman.service.d
+    install -m 0644 ${WORKDIR}/disable_dns_proxy.conf ${D}${sysconfdir}/systemd/system/connman.service.d/
 }
 

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/connman/files/disable_dns_proxy.conf
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/connman/files/disable_dns_proxy.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/connmand -n --nodnsproxy

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/dnsmasq_2.%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/dnsmasq_2.%.bbappend
@@ -1,0 +1,13 @@
+do_install_append() {
+    # Make dnsmasq listen only on bridge interface
+    echo "interface=xenbr0" >> ${D}${sysconfdir}/dnsmasq.conf
+
+    # Define DHCP leases range. Upper part of subnet can be used
+    # for static configuration.
+    echo "dhcp-range=192.168.0.2,192.168.0.150,12h" >> ${D}${sysconfdir}/dnsmasq.conf
+
+    # Configure addresses for DomF and DomA. Mac addresses
+    # are the same as in /xt/conf/*.conf
+    echo "dhcp-host=08:00:27:ff:cb:cd,domf,192.168.0.3,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
+    echo "dhcp-host=08:00:27:ff:cb:ce,doma,192.168.0.4,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
+}

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/dnsmasq_2.%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/dnsmasq_2.%.bbappend
@@ -10,4 +10,7 @@ do_install_append() {
     # are the same as in /xt/conf/*.conf
     echo "dhcp-host=08:00:27:ff:cb:cd,domf,192.168.0.3,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
     echo "dhcp-host=08:00:27:ff:cb:ce,doma,192.168.0.4,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
+
+    # Use resolve.conf provided by systemd-resolved
+    echo "resolv-file=/run/systemd/resolve/resolv.conf" >> ${D}${sysconfdir}/dnsmasq.conf
 }

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/systemd/files/ip_forward.conf
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/systemd/files/ip_forward.conf
@@ -1,0 +1,1 @@
+t /proc/sys/net/ipv4/ip_forward - - - - security.SMACK64=System

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/systemd/systemd_%.bbappend
@@ -5,5 +5,6 @@ SRC_URI_append = " \
 "
 
 PACKAGECONFIG_append = " networkd"
+PACKAGECONFIG_append = " iptc"
 
 USERADD_ERROR_DYNAMIC = "warn"

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/systemd/systemd_%.bbappend
@@ -2,9 +2,14 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_append = " \
     file://0001-networkd-link_enter_configured-remove-assert-4800.patch \
+    file://ip_forward.conf \
 "
 
 PACKAGECONFIG_append = " networkd"
 PACKAGECONFIG_append = " iptc"
 
 USERADD_ERROR_DYNAMIC = "warn"
+
+do_install_append() {
+    install -m 0644 ${WORKDIR}/ip_forward.conf ${D}${sysconfdir}/tmpfiles.d/
+}

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/systemd/systemd_%.bbappend
@@ -7,6 +7,7 @@ SRC_URI_append = " \
 
 PACKAGECONFIG_append = " networkd"
 PACKAGECONFIG_append = " iptc"
+PACKAGECONFIG_append = " resolved"
 
 USERADD_ERROR_DYNAMIC = "warn"
 

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/eth0.network
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/eth0.network
@@ -2,4 +2,4 @@
 Name=eth0
 
 [Network]
-Bridge=xenbr0
+DHCP=yes

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/xenbr0-systemd-networkd.conf
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/xenbr0-systemd-networkd.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPost=/usr/sbin/ethtool -K xenbr0 tx off

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/xenbr0.network
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/xenbr0.network
@@ -2,5 +2,5 @@
 Name=xenbr0
 
 [Network]
-Address=192.168.1.11/24
-Gateway=192.168.1.100
+Address=192.168.0.1/24
+IPMasquerade=yes

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
@@ -20,6 +20,7 @@ SRC_URI = " \
     file://eth0.network \
     file://xenbr0.netdev \
     file://xenbr0.network \
+    file://xenbr0-systemd-networkd.conf \
 "
 
 S = "${WORKDIR}"
@@ -37,6 +38,7 @@ FILES_${PN}-bridge-config = " \
     ${sysconfdir}/systemd/network/eth0.network \
     ${sysconfdir}/systemd/network/xenbr0.netdev \
     ${sysconfdir}/systemd/network/xenbr0.network \
+    ${sysconfdir}/systemd/system/systemd-networkd.service.d/xenbr0-systemd-networkd.conf \
 "
 
 SYSTEMD_PACKAGES = " \
@@ -64,6 +66,9 @@ FILES_${PN}-displbe-service = " \
 FILES_${PN}-bridge-up-notification-service = " \
     ${systemd_system_unitdir}/bridge-up-notification.service \
 "
+RDEPENDS_${PN}-bridge-config = " \
+    ethtool \
+"
 
 do_install() {
     install -d ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}
@@ -78,6 +83,9 @@ do_install() {
     install -d ${D}${sysconfdir}/systemd/network/
     install -m 0644 ${WORKDIR}/*.network ${D}${sysconfdir}/systemd/network
     install -m 0644 ${WORKDIR}/*.netdev ${D}${sysconfdir}/systemd/network
+
+    install -d ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d
+    install -m 0644 ${WORKDIR}/xenbr0-systemd-networkd.conf ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d
 }
 
 FILES_${PN} = " \


### PR DESCRIPTION
 - Physical eth0 is no longer belongs to xenbr0
 - eth0 is configured via DHCP from external network
 - xenbr0 has address 192.168.0.1
 - doma will receive address 192.168.0.4
 - domf will receive address 192.168.0.3
 - domd routes requests from guests to external networkd
 - dnsmasq added to domd to serve as DNS and DHCP server
 
If you want to access guests (apart from domd) from your PC, you need to establish DNAT in domd:
` # iptables -t nat -A PREROUTING -p tcp --dport 2023 -j DNAT --to-destination 192.168.0.3:22 -i eth0`

This example forwards port 2023 from DomD to port 22 (SSH) on DomF.