### PR TITLE
domd: network: forward ports to DomF and DomA

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/port-forward-systemd-networkd.conf
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/port-forward-systemd-networkd.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStartPost=/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 2022 -j DNAT --to-destination 192.168.0.3:22
+ExecStartPost=/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 5555 -j DNAT --to-destination 192.168.0.4:5555

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
@@ -24,6 +24,7 @@ SRC_URI = " \
     file://xenbr0.netdev \
     file://xenbr0.network \
     file://xenbr0-systemd-networkd.conf \
+    file://port-forward-systemd-networkd.conf \
 "
 
 S = "${WORKDIR}"
@@ -43,6 +44,7 @@ FILES_${PN}-bridge-config = " \
     ${sysconfdir}/systemd/network/xenbr0.netdev \
     ${sysconfdir}/systemd/network/xenbr0.network \
     ${sysconfdir}/systemd/system/systemd-networkd.service.d/xenbr0-systemd-networkd.conf \
+    ${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf \
 "
 
 SYSTEMD_PACKAGES = " \
@@ -100,6 +102,7 @@ do_install() {
 
     install -d ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d
     install -m 0644 ${WORKDIR}/xenbr0-systemd-networkd.conf ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d
+    install -m 0644 ${WORKDIR}/port-forward-systemd-networkd.conf ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d
 
     install -d ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_CFG}
     install -m 0744 ${WORKDIR}/${DM_CONFIG} ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_CFG}/dm.cfg


### PR DESCRIPTION
This patch forwards two ports from DomD to guests:

- port 5555 will be forwarded to DomA, so one can use ADB
- port 2022 will be forwarded to DomF port 22. This alows SSH access.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>