### PR TITLE
domd: Run display manager as a user service

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
@@ -35,7 +35,6 @@ PACKAGES += " \
     ${PN}-displbe-service \
     ${PN}-android-disks-service \
     ${PN}-bridge-up-notification-service \
-    ${PN}-display-manager.service \
 "
 
 FILES_${PN}-bridge-config = " \
@@ -49,7 +48,6 @@ SYSTEMD_PACKAGES = " \
     ${PN}-displbe-service \
     ${PN}-android-disks-service \
     ${PN}-bridge-up-notification-service \
-    ${PN}-display-manager.service \
 "
 
 SYSTEMD_SERVICE_${PN}-displbe-service = " displbe.service"
@@ -57,8 +55,6 @@ SYSTEMD_SERVICE_${PN}-displbe-service = " displbe.service"
 SYSTEMD_SERVICE_${PN}-android-disks-service = " android-disks.service"
 
 SYSTEMD_SERVICE_${PN}-bridge-up-notification-service = " bridge-up-notification.service"
-
-SYSTEMD_SERVICE_${PN}-display-manager.service = " display-manager.service"
 
 FILES_${PN}-android-disks-service = " \
     ${systemd_system_unitdir}/android-disks.service \
@@ -77,10 +73,6 @@ RDEPENDS_${PN}-bridge-config = " \
     ethtool \
 "
 
-FILES_${PN}-display-manager.service = " \
-    ${systemd_system_unitdir}/display-manager.service \
-"
-
 DM_CONFIG_salvator-x-m3-xt = "dm-salvator-x-m3.cfg"
 DM_CONFIG_salvator-x-h3-xt = "dm-salvator-x-h3.cfg"
 
@@ -90,6 +82,15 @@ do_install() {
 
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/*.service ${D}${systemd_system_unitdir}
+
+    # N.B. display-manager must be installed as a user service which
+    # is not supported by systemd.bbclass at the moment, so
+    # do all dirty work by hands
+    rm ${D}${systemd_system_unitdir}/display-manager.service
+    install -d ${D}${systemd_user_unitdir}
+    install -m 0644 ${WORKDIR}/display-manager.service ${D}${systemd_user_unitdir}
+    install -d ${D}${sysconfdir}/systemd/user/default.target.wants
+    ln -sf ${systemd_user_unitdir}/display-manager.service ${D}${sysconfdir}/systemd/user/default.target.wants
 
     install -d ${D}${sysconfdir}/tmpfiles.d
     install -m 0644 ${WORKDIR}/android-disks.conf ${D}${sysconfdir}/tmpfiles.d/android-disks.conf
@@ -108,5 +109,7 @@ do_install() {
 FILES_${PN} = " \
     ${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}/*.sh \
     ${base_prefix}${XT_DIR_ABS_ROOTFS_CFG}/*.cfg \
+    ${systemd_user_unitdir}/display-manager.service \
+    ${base_prefix}${sysconfdir}/systemd/user/default.target.wants \
 "
 


### PR DESCRIPTION
Display manager needs to run as a user service, not
as a system one.

User services are not supported by systemd.bbclass at the moment, so
do all dirty work by hands.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>