### PR TITLE
domd: connman: fix path to connmand

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/connman/files/disable_dns_proxy.conf
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/connman/files/disable_dns_proxy.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/connmand -n --nodnsproxy
+ExecStart=/usr/sbin/connmand -n --nodnsproxy


### PR DESCRIPTION
On AGL distro connmand is situated in /usr/sbin, not /usr/bin.
This caused problem when systemd can't start connmand, which
in turn prevented to start any dependencies.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>