### PR TITLE
Set ondemand governor for Xen based CPUFreq 

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-dom0.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-dom0.dts
@@ -51,7 +51,7 @@
 	};
 
 	chosen {
-		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 flask_enforcing=1 loglvl=all cpufreq=xen:userspace,speed=1500000";
+		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 flask_enforcing=1 loglvl=all cpufreq=xen:ondemand";
 		xen,dom0-bootargs = "console=hvc0 ignore_loglevel";
 		modules {
 			#address-cells = <2>;

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-dom0.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-dom0.dts
@@ -51,7 +51,7 @@
 	};
 
 	chosen {
-		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 flask_enforcing=1 loglvl=all cpufreq=xen:userspace,speed=1500000";
+		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 flask_enforcing=1 loglvl=all cpufreq=xen:ondemand";
 		xen,dom0-bootargs = "console=hvc0 ignore_loglevel";
 		modules {
 			#address-cells = <2>;


### PR DESCRIPTION
With this patch set included, CPUFreq will switch OPP in runtime.

If you want to just disable DVFS without rebuilding the whole dom0 device-tree, you need to run following commands in dom0 console every time the system has been powered on:
`xenpm set-scaling-governor 0 userspace`
`xenpm set-scaling-speed 0 1500000`

If you want to disable CPUFreq (with thermal) without rebuilding the whole dom0 device-tree, you need to run following commands in U-Boot console:
`setenv bootargs 'dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 flask_enforcing=1 loglvl=all cpufreq=none'`
`saveenv`
  