### PR TITLE
domd: bridge-up-notification.service: restart on networkd restart

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/bridge-up-notification.service
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/bridge-up-notification.service
@@ -1,14 +1,16 @@
 [Unit]
 Description=Bridge up notification
-Requires=systemd-networkd.service
+Wants=systemd-networkd.service
 After=systemd-networkd.service
 
 [Service]
-Type=oneshot
-ExecStart=/sbin/ifconfig xenbr0
+Type=simple
+ExecStartPre=/sbin/ifconfig xenbr0
 ExecStart=/usr/bin/xenstore-write drivers/bridge/status ready
 RemainAfterExit=yes
 ExecStopPost=/usr/bin/xenstore-write drivers/bridge/status dead
+Restart=on-failure
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Oneshot service does not restart if first boot of networkd fails.
Change its type to simple and make it restartable.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>