### PR TITLE
dom0: Increase gnttab_max_frames to 64

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-dom0.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-dom0.dts
@@ -51,7 +51,7 @@
 	};
 
 	chosen {
-		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 flask_enforcing=1 loglvl=all cpufreq=xen:ondemand";
+		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 flask_enforcing=1 loglvl=all cpufreq=xen:ondemand gnttab_max_frames=64";
 		xen,dom0-bootargs = "console=hvc0 ignore_loglevel";
 		modules {
 			#address-cells = <2>;

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-dom0.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-dom0.dts
@@ -51,7 +51,7 @@
 	};
 
 	chosen {
-		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 flask_enforcing=1 loglvl=all cpufreq=xen:ondemand";
+		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 flask_enforcing=1 loglvl=all cpufreq=xen:ondemand gnttab_max_frames=64";
 		xen,dom0-bootargs = "console=hvc0 ignore_loglevel";
 		modules {
 			#address-cells = <2>;


### PR DESCRIPTION
At the moment Android uses lots of grant references and
behaves much better and more stable if their number
is increased to 64k from default 32k.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>