### PR TITLE
domd: use correct dependency in sensors-emulator.service

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/sensors-emulator/files/sensors-emulator.service
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/sensors-emulator/files/sensors-emulator.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Car sensors data emulator
-Requires=systemd-networkd.service
+Wants=systemd-networkd.service
 After=systemd-networkd.service
 
 [Service]


### PR DESCRIPTION
Requires= is to strong it this case. We need to use Wants=

There is what documentation says:

    Wants =
    A weaker version of Requires=. Units listed in this option will be
    started if the configuring unit is. However, if the listed units
    fail to start or cannot be added to the transaction, this has no
    impact on the validity of the transaction as a whole. ** This is
    the recommended way to hook start-up of one unit to the start-up
    of another unit. **

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>