### PR TITLE
Bring-up all cores and pin dom0(F) VCPUs

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -9,6 +9,7 @@ IMAGE_INSTALL_append = " \
     guest-addons-run-doma \
     guest-addons-run-domd \
     guest-addons-run-domf \
+    guest-addons-run-vcpu_pin \
     domd-install-artifacts \
     doma-install-artifacts \
     domf-install-artifacts \

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/dom0_vcpu_pin.sh
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/dom0_vcpu_pin.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides: vcpu-pin
+# Required-Start:
+# Required-Stop:
+# Default-Start:     S
+# Default-Stop:
+### END INIT INFO
+
+# Force all VCPUs of Domain-0 to only run on PCPUs from 4 to 7 (A53 cores)
+echo "Pinning Domain-0 VCPUs"
+xl vcpu-pin Domain-0 all 4-7

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domf.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domf.cfg
@@ -14,6 +14,9 @@ memory = 192
 
 vcpus = 1
 
+# Force all VCPUs of DomF to only run on PCPUs from 4 to 7 (A53 cores)
+cpus="4-7"
+
 disk = [ 'backend=DomD,phy:/dev/mmcblk1p3,xvda1' ]
 
 vif = [ 'backend=DomD,bridge=xenbr0,mac=08:00:27:ff:cb:cd' ]

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
@@ -17,6 +17,7 @@ SRC_URI = "\
     file://guest_domd \
     file://guest_domf \
     file://start_guest.sh \
+    file://dom0_vcpu_pin.sh \
 "
 
 S = "${WORKDIR}"
@@ -45,14 +46,19 @@ FILES_${PN}-run-domf += " \
     ${sysconfdir}/init.d/guest_domf \
 "
 
+FILES_${PN}-run-vcpu_pin += " \
+    ${sysconfdir}/init.d/dom0_vcpu_pin.sh \
+"
+
 PACKAGES += " \
     ${PN}-run-domd \
     ${PN}-run-doma \
     ${PN}-run-domf \
+    ${PN}-run-vcpu_pin \
 "
 
 # configure init.d scripts
-INITSCRIPT_PACKAGES = "${PN}-run-domd ${PN}-run-doma ${PN}-run-domf"
+INITSCRIPT_PACKAGES = "${PN}-run-domd ${PN}-run-doma ${PN}-run-domf ${PN}-run-vcpu_pin"
 
 INITSCRIPT_NAME_${PN}-run-domd = "guest_domd"
 INITSCRIPT_PARAMS_${PN}-run-domd = "defaults 85"
@@ -60,6 +66,8 @@ INITSCRIPT_NAME_${PN}-run-domf = "guest_domf"
 INITSCRIPT_PARAMS_${PN}-run-domf = "defaults 86"
 INITSCRIPT_NAME_${PN}-run-doma = "guest_doma"
 INITSCRIPT_PARAMS_${PN}-run-doma = "defaults 87"
+INITSCRIPT_NAME_${PN}-run-vcpu_pin = "dom0_vcpu_pin.sh"
+INITSCRIPT_PARAMS_${PN}-run-vcpu_pin = "defaults 81"
 
 do_install() {
     install -d ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}
@@ -73,4 +81,5 @@ do_install() {
     install -m 0744 ${WORKDIR}/guest_doma ${D}${sysconfdir}/init.d/
     install -m 0744 ${WORKDIR}/start_guest.sh ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}/
     install -m 0744 ${WORKDIR}/guest_domf ${D}${sysconfdir}/init.d/
+    install -m 0744 ${WORKDIR}/dom0_vcpu_pin.sh ${D}${sysconfdir}/init.d/
 }

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
@@ -1,5 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
+# Boot all available cores
+ATFW_OPT_append = " PSCI_DISABLE_BIGLITTLE_IN_CA57BOOT=0"
+
 BRANCH = "scp_devel"
 SRC_URI = "git://github.com/xen-troops/arm-trusted-firmware.git;branch=${BRANCH}"
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
With this patch set included ARM TF will bring-up all cores and perform boot from A57 CPU0. This patch set also adds VCPU pinning for certain domains.
There is a map how domains will use physical CPUs:
dom0 - only A53 CPUs
domD - all CPUs (A53 + A57)
domF - only A53 CPUs
domA - all CPUs (A53 + A57)

P.S. This patch set won't work on M3. Need to be fixed.
  
  