### PR TITLE
domd: enable ntpdate and tzdata

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
@@ -18,6 +18,8 @@ IMAGE_INSTALL_append = " \
 IMAGE_INSTALL_append = " \
     dnsmasq \
     nftables \
+    ntpdate-systemd \
+    tzdata \
     dhcp-client \
     xen-base \
     xen-flask \

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-support/ntp/ntp/ntpdate.default
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-support/ntp/ntp/ntpdate.default
@@ -1,0 +1,7 @@
+# Configuration script used by ntpdate-sync script
+
+NTPSERVERS="0.pool.ntp.org"
+
+# Set to "yes" to write time to hardware clock on success
+UPDATE_HWCLOCK="no"
+

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-support/ntp/ntp/ntpdate.service
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-support/ntp/ntp/ntpdate.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Network Time Service (one-shot ntpdate mode)
+Wants=network-online.target
+After=network-online.target
+After=connman.service
+After=dnsmasq.service
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/sleep 5
+ExecStart=/usr/bin/ntpdate-sync silent
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-support/ntp/ntp_4.2.8p9.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-support/ntp/ntp_4.2.8p9.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/ntp:"


### PR DESCRIPTION
This patch adds ntpdate and tzdata to image, so domd
can set time auotomatically.

ntpdate stars when network is ready and is configured
to sync with 0.pool.ntp.org

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>