### PR TITLE
domd: Configure Weston outputs

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/wayland/weston-ini-conf.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/wayland/weston-ini-conf.bbappend
@@ -15,3 +15,8 @@ python () {
         d.setVarFlag("WESTONOUTPUT4", "mode", "off")
 }
 
+python () {
+    if "salvator-x-m3-xt" in d.getVar("MACHINEOVERRIDES", expand=True):
+        d.setVarFlag("DEFAULT_SCREEN", "transform", "0")
+}
+


### PR DESCRIPTION
    Configure Weston display output:
    for salvator-x-m3 set HDMI monitor transform to "0"

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>