### PR TITLE
Document how to flash bootloader image(s) to eMMC's boot partitions

### DIFF
--- a/doc/u-boot-env-salvator-x-h3-m3.txt
+++ b/doc/u-boot-env-salvator-x-h3-m3.txt
@@ -54,6 +54,20 @@ setenv emmc_kernel_load ext2load mmc 1:1 0x7a000000 /boot/Image
 setenv emmc_xen_load ext2load mmc 1:1 0x48080000 /boot/xen-uImage
 setenv emmc_xenpolicy_load ext2load mmc 1:1 0x7c000000 /boot/xenpolicy
 
+Bootloaders from eMMC:
+===================================
+In case of boot SoC from the eMMC boot partition 1 (50MHz x8 bus width mode) instead of Serial Flash,
+we have an ability to flash bootloader image(s) right here in U-Boot (images must be in raw binary format).
+Partitions and offsets the images need to be flashed to were retrieved here:
+https://github.com/renesas-rcar/flash_writer/blob/rcar_gen3/docs/application-note.md#348-write-to-the-s-record-format-images-to-the-emmc
+
+setenv flash_bootparam_sa0 'tftp 0x48000000 bootparam_sa0.bin; mmc dev 1 1; mmc write 0x48000000 0x0 0x1E;'
+setenv flash_bl2 'tftp 0x48000000 bl2.bin; mmc dev 1 1; mmc write 0x48000000 0x1E 0x162;'
+setenv flash_cert_header_sa6 'tftp 0x48000000 cert_header_sa6_emmc.bin; mmc dev 1 1; mmc write 0x48000000 0x180 0x80;'
+setenv flash_bl31 'tftp 0x48000000 bl31.bin; mmc dev 1 1; mmc write 0x48000000 0x200 0xE00;'
+setenv flash_tee 'tftp 0x48000000 tee.bin; mmc dev 1 1; mmc write 0x48000000 0x1000 0x400;'
+setenv flash_u_boot 'tftp 0x48000000 u-boot.bin; mmc dev 1 2; mmc write 0x48000000 0x0 0x800;'
+setenv flash_loaders 'run flash_bootparam_sa0; run flash_bl2; run flash_cert_header_sa6; run flash_bl31; run flash_tee; run flash_u_boot;'
 
 setenv ethact ravb
 

--- a/doc/u-boot-env-salvator-x-h3-m3.txt
+++ b/doc/u-boot-env-salvator-x-h3-m3.txt
@@ -9,31 +9,18 @@ storage device without "/dev/", e.g.
 setenv boot_dev mmcblk1
 setenv set_boot_dev 'fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device ${boot_dev}'
 
-Salvator-X-H3
+Salvator-X-H3/M3
 ===================================
 
 setenv bootdelay 3
 setenv baudrate 115200
 
 for tftp boot:
+===================================
 
 setenv boot_dev nfs
 setenv bootcmd run bootcmd_xen_tftp
 setenv bootcmd_xen_tftp 'run xen_load_tftp; run dtb_load_tftp; run kernel_load_tftp; run xenpolicy_load_tftp; run initramfs_load_tftp; bootm 0x48080000 0x76000000 0x48000000'
-
-for SD card boot:
-
-setenv boot_dev mmcblk1
-setenv bootcmd run bootcmd_xen_mmc
-setenv bootcmd_xen_mmc 'run mmc_xen_load; run mmc_dtb_load; run mmc_kernel_load; run mmc_xenpolicy_load; run mmc_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
-
-for eMMC boot:
-setenv boot_dev mmcblk0
-setenv bootcmd run bootcmd_xen_emmc
-setenv bootcmd_xen_emmc 'run emmc_xen_load; run emmc_dtb_load; run emmc_kernel_load; run emmc_xenpolicy_load; run emmc_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
-
-setenv fileaddr 7a000000
-setenv filesize da4e00
 
 setenv dtb_load_tftp 'tftp 0x48000000 dom0.dtb; run set_boot_dev'
 setenv xen_load_tftp tftp 0x48080000 xen-uImage
@@ -41,6 +28,12 @@ setenv initramfs_load_tftp tftp 0x76000000 uInitramfs
 setenv kernel_load_tftp tftp 0x7a000000 Image
 setenv xenpolicy_load_tftp tftp 0x7c000000 xenpolicy
 
+for SD card boot:
+===================================
+
+setenv boot_dev mmcblk1
+setenv bootcmd run bootcmd_xen_mmc
+setenv bootcmd_xen_mmc 'run mmc_xen_load; run mmc_dtb_load; run mmc_kernel_load; run mmc_xenpolicy_load; run mmc_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
 
 setenv mmc_dtb_load 'ext2load mmc 0:1 0x48000000 /boot/dom0.dtb; run set_boot_dev'
 setenv mmc_initramfs_load ext2load mmc 0:1 0x76000000 /boot/uInitramfs
@@ -48,7 +41,13 @@ setenv mmc_kernel_load ext2load mmc 0:1 0x7a000000 /boot/Image
 setenv mmc_xen_load ext2load mmc 0:1 0x48080000 /boot/xen-uImage
 setenv mmc_xenpolicy_load ext2load mmc 0:1 0x7c000000 /boot/xenpolicy
 
-for eMMC:
+for eMMC boot:
+===================================
+
+setenv boot_dev mmcblk0
+setenv bootcmd run bootcmd_xen_emmc
+setenv bootcmd_xen_emmc 'run emmc_xen_load; run emmc_dtb_load; run emmc_kernel_load; run emmc_xenpolicy_load; run emmc_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
+
 setenv emmc_dtb_load 'ext2load mmc 1:1 0x48000000 /boot/dom0.dtb; run set_boot_dev'
 setenv emmc_initramfs_load ext2load mmc 1:1 0x76000000 /boot/uInitramfs
 setenv emmc_kernel_load ext2load mmc 1:1 0x7a000000 /boot/Image

--- a/doc/u-boot-env-salvator-x-h3-m3.txt
+++ b/doc/u-boot-env-salvator-x-h3-m3.txt
@@ -1,3 +1,14 @@
+Boot storage device setting
+===================================
+In order to make it possible to boot from various storage devices,
+e.g. SD, eMMC etc, a some settings need to be done in the environment:
+setenv boot_dev=<dev-name>, where <dev-name> is the name of the
+storage device without "/dev/", e.g.
+"setenv boot_dev memcblk0" to boot from eMMC
+
+setenv boot_dev mmcblk1
+setenv set_boot_dev 'fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device ${boot_dev}'
+
 Salvator-X-H3
 ===================================
 
@@ -6,29 +17,44 @@ setenv baudrate 115200
 
 for tftp boot:
 
+setenv boot_dev nfs
 setenv bootcmd run bootcmd_xen_tftp
 setenv bootcmd_xen_tftp 'run xen_load_tftp; run dtb_load_tftp; run kernel_load_tftp; run xenpolicy_load_tftp; run initramfs_load_tftp; bootm 0x48080000 0x76000000 0x48000000'
 
 for SD card boot:
 
+setenv boot_dev mmcblk1
 setenv bootcmd run bootcmd_xen_mmc
 setenv bootcmd_xen_mmc 'run mmc_xen_load; run mmc_dtb_load; run mmc_kernel_load; run mmc_xenpolicy_load; run mmc_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
+
+for eMMC boot:
+setenv boot_dev mmcblk0
+setenv bootcmd run bootcmd_xen_emmc
+setenv bootcmd_xen_emmc 'run emmc_xen_load; run emmc_dtb_load; run emmc_kernel_load; run emmc_xenpolicy_load; run emmc_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
 
 setenv fileaddr 7a000000
 setenv filesize da4e00
 
-setenv dtb_load_tftp tftp 0x48000000 dom0.dtb
+setenv dtb_load_tftp 'tftp 0x48000000 dom0.dtb; run set_boot_dev'
 setenv xen_load_tftp tftp 0x48080000 xen-uImage
 setenv initramfs_load_tftp tftp 0x76000000 uInitramfs
 setenv kernel_load_tftp tftp 0x7a000000 Image
 setenv xenpolicy_load_tftp tftp 0x7c000000 xenpolicy
 
 
-setenv mmc_dtb_load ext2load mmc 0:1 0x48000000 /boot/dom0.dtb
+setenv mmc_dtb_load 'ext2load mmc 0:1 0x48000000 /boot/dom0.dtb; run set_boot_dev'
 setenv mmc_initramfs_load ext2load mmc 0:1 0x76000000 /boot/uInitramfs
 setenv mmc_kernel_load ext2load mmc 0:1 0x7a000000 /boot/Image
 setenv mmc_xen_load ext2load mmc 0:1 0x48080000 /boot/xen-uImage
 setenv mmc_xenpolicy_load ext2load mmc 0:1 0x7c000000 /boot/xenpolicy
+
+for eMMC:
+setenv emmc_dtb_load 'ext2load mmc 1:1 0x48000000 /boot/dom0.dtb; run set_boot_dev'
+setenv emmc_initramfs_load ext2load mmc 1:1 0x76000000 /boot/uInitramfs
+setenv emmc_kernel_load ext2load mmc 1:1 0x7a000000 /boot/Image
+setenv emmc_xen_load ext2load mmc 1:1 0x48080000 /boot/xen-uImage
+setenv emmc_xenpolicy_load ext2load mmc 1:1 0x7c000000 /boot/xenpolicy
+
 
 setenv ethact ravb
 

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -10,6 +10,7 @@ IMAGE_INSTALL_append = " \
     guest-addons-run-domd \
     guest-addons-run-domf \
     guest-addons-run-vcpu_pin \
+    guest-addons-run-set_root_dev \
     domd-install-artifacts \
     doma-install-artifacts \
     domf-install-artifacts \

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3.cfg
@@ -14,7 +14,7 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 #extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd ip=192.168.1.11 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
-extra = "root=/dev/mmcblk1p2 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
 
 # Initial memory allocation (MB)
 memory = 1024

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-m3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-m3.cfg
@@ -14,7 +14,7 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 #extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd ip=192.168.1.11 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
-extra = "root=/dev/mmcblk1p2 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
 
 # Initial memory allocation (MB)
 memory = 1024

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domf.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domf.cfg
@@ -17,7 +17,7 @@ vcpus = 1
 # Force all VCPUs of DomF to only run on DOMF_ALLOWED_PCPUS PCPUs (A53 cores)
 cpus="DOMF_ALLOWED_PCPUS"
 
-disk = [ 'backend=DomD,phy:/dev/mmcblk1p3,xvda1' ]
+disk = [ 'backend=DomD,phy:/dev/STORAGE_PART3,xvda1' ]
 
 vif = [ 'backend=DomD,bridge=xenbr0,mac=08:00:27:ff:cb:cd' ]
 

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/xt_set_root_dev_cfg.sh
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/xt_set_root_dev_cfg.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides: xt_set_root_dev_cfg
+# Required-Start:
+# Required-Stop:
+# Default-Start:     S
+# Default-Stop:
+### END INIT INFO
+
+# Change domain configuration to boot from storage configured by u-boot
+DOM_CFG_DIR="/xt/dom.cfg"
+
+# detect boot storage device
+BOOT_STORAGE=`cat /proc/device-tree/boot_dev/device`
+if [ -z "$BOOT_STORAGE" ] ; then
+	BOOT_STORAGE=mmcblk1
+	echo "WARNING! Using default storage: ${BOOT_STORAGE}"
+fi
+
+# guess partition prefix, e.g. "" for sda2 or "p" for mmcblk1p2
+PART_PREFIX=""
+if echo "${BOOT_STORAGE}" | grep -q 'mmc' ; then
+   PART_PREFIX="p"
+fi
+STORAGE_PART="${BOOT_STORAGE}${PART_PREFIX}"
+
+# now make up the configuration
+echo "Mangling domain configuration: setting storage to ${BOOT_STORAGE}"
+sed -i "s/STORAGE_PART/${STORAGE_PART}/g" ${DOM_CFG_DIR}/domd.cfg
+sed -i "s/STORAGE_PART/${STORAGE_PART}/g" ${DOM_CFG_DIR}/domf.cfg

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
@@ -18,6 +18,7 @@ SRC_URI = "\
     file://guest_domf \
     file://start_guest.sh \
     file://dom0_vcpu_pin.sh \
+    file://xt_set_root_dev_cfg.sh \
 "
 
 S = "${WORKDIR}"
@@ -56,15 +57,20 @@ FILES_${PN}-run-vcpu_pin += " \
     ${sysconfdir}/init.d/dom0_vcpu_pin.sh \
 "
 
+FILES_${PN}-run-set_root_dev += " \
+    ${sysconfdir}/init.d/xt_set_root_dev_cfg.sh \
+"
+
 PACKAGES += " \
     ${PN}-run-domd \
     ${PN}-run-doma \
     ${PN}-run-domf \
     ${PN}-run-vcpu_pin \
+    ${PN}-run-set_root_dev \
 "
 
 # configure init.d scripts
-INITSCRIPT_PACKAGES = "${PN}-run-domd ${PN}-run-doma ${PN}-run-domf ${PN}-run-vcpu_pin"
+INITSCRIPT_PACKAGES = "${PN}-run-domd ${PN}-run-doma ${PN}-run-domf ${PN}-run-vcpu_pin ${PN}-run-set_root_dev"
 
 INITSCRIPT_NAME_${PN}-run-domd = "guest_domd"
 INITSCRIPT_PARAMS_${PN}-run-domd = "defaults 85"
@@ -74,6 +80,9 @@ INITSCRIPT_NAME_${PN}-run-doma = "guest_doma"
 INITSCRIPT_PARAMS_${PN}-run-doma = "defaults 87"
 INITSCRIPT_NAME_${PN}-run-vcpu_pin = "dom0_vcpu_pin.sh"
 INITSCRIPT_PARAMS_${PN}-run-vcpu_pin = "defaults 81"
+# must run before any domain creation
+INITSCRIPT_NAME_${PN}-run-set_root_dev = "xt_set_root_dev_cfg.sh"
+INITSCRIPT_PARAMS_${PN}-run-set_root_dev = "defaults 82"
 
 do_install() {
     install -d ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}
@@ -88,6 +97,7 @@ do_install() {
     install -m 0744 ${WORKDIR}/start_guest.sh ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}/
     install -m 0744 ${WORKDIR}/guest_domf ${D}${sysconfdir}/init.d/
     install -m 0744 ${WORKDIR}/dom0_vcpu_pin.sh ${D}${sysconfdir}/init.d/
+    install -m 0744 ${WORKDIR}/xt_set_root_dev_cfg.sh ${D}${sysconfdir}/init.d/
 
     # Fixup a number of PCPUs the VCPUs of DomF must run on
     sed -i "s/DOMF_ALLOWED_PCPUS/${DOMF_ALLOWED_PCPUS}/g" ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}/domf.cfg

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
@@ -10,3 +10,9 @@ SRCREV = "${AUTOREV}"
 SRC_URI_append = " \
     file://0001-BL2-Disable-TLB-cache-function-of-IPMMU-caches.patch \
 "
+
+do_deploy_append () {
+    install -m 0644 ${S}/tools/dummy_create/bootparam_sa0.bin ${DEPLOYDIR}/bootparam_sa0.bin
+    install -m 0644 ${S}/tools/dummy_create/cert_header_sa6.bin ${DEPLOYDIR}/cert_header_sa6.bin
+}
+

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
@@ -14,5 +14,7 @@ SRC_URI_append = " \
 do_deploy_append () {
     install -m 0644 ${S}/tools/dummy_create/bootparam_sa0.bin ${DEPLOYDIR}/bootparam_sa0.bin
     install -m 0644 ${S}/tools/dummy_create/cert_header_sa6.bin ${DEPLOYDIR}/cert_header_sa6.bin
+    install -m 0644 ${S}/tools/dummy_create/cert_header_sa6_emmc.bin ${DEPLOYDIR}/cert_header_sa6_emmc.bin
+    install -m 0644 ${S}/tools/dummy_create/cert_header_sa6_emmc.srec ${DEPLOYDIR}/cert_header_sa6_emmc.srec
 }
 

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/android-disks.sh
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/android-disks.sh
@@ -14,10 +14,23 @@ then
 
     cd $RAW_FOLDER && /xt/scripts/doma_loop_setup.sh || exit 1
 else
-    ln -s /dev/mmcblk1p5 $ADISKS_FOLDER/system
-    ln -s /dev/mmcblk1p6 $ADISKS_FOLDER/vendor
-    ln -s /dev/mmcblk1p7 $ADISKS_FOLDER/misc
-    ln -s /dev/mmcblk1p8 $ADISKS_FOLDER/userdata
+# different block devices have different naming for partitions,
+# e.g. sda will have <sda>2 while mmcblk1 will have <mmcblk1>p2
+    BOOT_STORAGE=`cat /proc/cmdline | sed -e 's#^.*\broot=/dev/##' -e 's/ .*$//'`
+    if [ -z "$BOOT_STORAGE" ]
+    then
+        BOOT_STORAGE=mmcblk1p2
+        echo "WARNING! Using default for storage device: ${BOOT_STORAGE}"
+    fi
+   echo "Using ${BOOT_STORAGE} as boot storage device"
+# get storage device name where root partition lives
+    BASE_DEV=`basename "$(readlink -f "/sys/class/block/${BOOT_STORAGE}/..")"`
+# get partition prefix, e.g. "" for sda2 or "p" for mmcblk1p2
+    PART_PREFIX=`echo ${BOOT_STORAGE} | eval sed -e 's/${BASE_DEV}//g' | sed 's/[0-9]\+//'`
+    ln -s /dev/${BASE_DEV}${PART_PREFIX}5 $ADISKS_FOLDER/system
+    ln -s /dev/${BASE_DEV}${PART_PREFIX}6 $ADISKS_FOLDER/vendor
+    ln -s /dev/${BASE_DEV}${PART_PREFIX}7 $ADISKS_FOLDER/misc
+    ln -s /dev/${BASE_DEV}${PART_PREFIX}8 $ADISKS_FOLDER/userdata
 fi
 
 xenstore-write drivers/disks/status ready

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/wayland/weston-ini-conf.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/wayland/weston-ini-conf.bbappend
@@ -15,3 +15,8 @@ python () {
         d.setVarFlag("WESTONOUTPUT4", "mode", "off")
 }
 
+python () {
+    if "salvator-x-m3-xt" in d.getVar("MACHINEOVERRIDES", expand=True):
+        d.setVarFlag("DEFAULT_SCREEN", "transform", "0")
+}
+


### PR DESCRIPTION
In case of boot SoC from the eMMC boot partition 1 (50MHz x8 bus width mode)
instead of Serial Flash, we have an ability to flash bootloader image(s)
right here in U-Boot (images must be in raw binary format).

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>