### PR TITLE
rescue: Generate SD card image with wic

### DIFF
--- a/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-rescue-initramfs.wks
+++ b/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-rescue-initramfs.wks
@@ -1,0 +1,1 @@
+part /boot --source bootimg-partition --fstype=ext4 --label boot --active --align 1 --size 64

--- a/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -7,13 +7,45 @@ IMAGE_INSTALL_append = " \
 
 IMAGE_ROOTFS_SIZE = "65535"
 
-DEPENDS += "u-boot-mkimage-native"
+DEPENDS += "u-boot-mkimage-native parted-native"
 
-generate_uboot_image() {
+addtask generate_uboot_image after do_image_cpio before do_image_wic
+
+do_generate_uboot_image() {
     ${STAGING_BINDIR_NATIVE}/uboot-mkimage -A arm64 -O linux -T ramdisk -C gzip -n "uInitramfs" \
         -d ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.cpio.gz ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.cpio.gz.uInitramfs
     ln -sfr  ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.cpio.gz.uInitramfs ${DEPLOY_DIR_IMAGE}/uInitramfs
 }
 
-IMAGE_POSTPROCESS_COMMAND += " generate_uboot_image;"
+###############################################################################
+# SD card image creation
+###############################################################################
+
+WKS_SEARCH_PATH := "${THISDIR}:${WKS_SEARCH_PATH}"
+
+IMAGE_FSTYPES_append = " wic"
+
+WKS_FILE = "core-image-rescue-initramfs.wks"
+
+IMAGE_BOOT_FILES = "\
+    Image;boot/Image \
+    uInitramfs;boot/uInitramfs \
+    dom0.dtb;boot/dom0.dtb \
+    xenpolicy;boot/xenpolicy \
+    xen-uImage;boot/xen-uImage \
+"
+
+addtask copy_xen_images after do_image_cpio before do_image_wic
+
+do_copy_xen_images() {
+    # find Xen components which are part of DomD build in its deploy dir
+    domd_name=`ls ${DEPLOY_DIR}/.. | grep domd`
+    domd_root="${DEPLOY_DIR}/../${domd_name}"
+
+    xenpolicy=`find $domd_root -name xenpolicy`
+    xenuImage=`find $domd_root -name xen-uImage`
+
+    cp -fL "${xenpolicy}" ${DEPLOY_DIR_IMAGE}
+    cp -fL "${xenuImage}" ${DEPLOY_DIR_IMAGE}
+}
 


### PR DESCRIPTION
http://www.yoctoproject.org/docs/current/dev-manual/dev-manual.html#creating-partitioned-images-using-wic

"Creating an image for a particular hardware target using the OpenEmbedded
build system does not necessarily mean you can boot that image as is on your
device. Physical devices accept and boot images in various ways depending
on the specifics of the device. Usually, information about the hardware can
tell you what image format the device requires. Should your device require
multiple partitions on an SD card, flash, or an HDD, you can use the
OpenEmbedded Image Creator, Wic, to create the properly partitioned image"

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>