### PR TITLE
doma: switch sound backend to alsa

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3.cfg
@@ -107,6 +107,6 @@ vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080;1001:768x1024' ]
 vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,id=T:1000' ]
 
 vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Virtual sound card, sample-rates=48000, sample-formats=s16_le',
-          'pcm, name=dev1', 'stream, id=pulse, type=P' ]]
+          'pcm, name=dev1', 'stream, id=alsa, type=P' ]]
 
 on_crash = 'preserve'

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-m3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-m3.cfg
@@ -87,6 +87,6 @@ vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080;1001:768x1024' ]
 vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,id=T:1000' ]
 
 vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Virtual sound card, sample-rates=48000, sample-formats=s16_le',
-          'pcm, name=dev1', 'stream, id=pulse, type=P' ]]
+          'pcm, name=dev1', 'stream, id=alsa, type=P' ]]
 
 on_crash = 'preserve'


### PR DESCRIPTION
Pulse sound backend works unstable. Once stability is fixed
need to be switched back to pulse.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>