### PR TITLE
domd: Do not configure eth0 if running with NFS root

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/eth0.network
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/eth0.network
@@ -1,5 +1,6 @@
 [Match]
 Name=eth0
+KernelCommandLine=!nfsroot
 
 [Network]
 DHCP=yes


### PR DESCRIPTION
eth0 interface must not be touched by systemd in case we are
running on NFS root filesystem. Instead, kernel configuration must be
used.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>