### PR TITLE
domd: Fix hostname

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
@@ -1,7 +1,7 @@
 require inc/xt_shared_env.inc
 
 # Append domain name
-hostname += "-domd"
+hostname .= "-domd"
 
 do_install_append () {
 	sed -i '/PATH="/a PATH="$PATH:${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}"' ${D}${sysconfdir}/profile


### PR DESCRIPTION
Bitbake's "+=" operator appends a string with a space while
".=" without. Use the later as hostname must not contain spaces.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>