### PR TITLE
domd: remove pulseaudio module-router

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -1,0 +1,2 @@
+# remote module-router as it is not functional
+SRC_URI_remove =  "file://0006-auto-load-module-router.patch"


### PR DESCRIPTION
module-router is the part of AudioManager but it is not
functional. This module prevents to connect capture stream
in sound backend. Once it becomes more usefull it should be
placed back.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>