### PR TITLE
doma: Change CMA size from 512M to 110M

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3.cfg
@@ -85,7 +85,7 @@ disk = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=salvator skip_initramfs init=/init ro rootwait console=hvc0 cma=512M printk.devkmsg=on androidboot.slot_suffix=1 androidboot.selinux=permissive pvrsrvkm.DriverMode=1"
+extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=salvator skip_initramfs init=/init ro rootwait console=hvc0 cma=110M printk.devkmsg=on androidboot.slot_suffix=1 androidboot.selinux=permissive pvrsrvkm.DriverMode=1"
 
 # Initial memory allocation (MB)
 memory = 2240

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-m3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-m3.cfg
@@ -65,7 +65,7 @@ disk = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=salvator skip_initramfs init=/init ro rootwait console=hvc0 cma=512M printk.devkmsg=on androidboot.slot_suffix=1 androidboot.selinux=permissive pvrsrvkm.DriverMode=1"
+extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=salvator skip_initramfs init=/init ro rootwait console=hvc0 cma=110M printk.devkmsg=on androidboot.slot_suffix=1 androidboot.selinux=permissive pvrsrvkm.DriverMode=1"
 
 # Initial memory allocation (MB)
 memory = 2240


### PR DESCRIPTION
After latest buffer allocation policy changes in Android
CMA size can be reduced to 110M.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>